### PR TITLE
feat: utilize type inference to infer the promise response type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,17 @@
-type AsyncAction = Promise<any> | ((...args: any[]) => Promise<AsyncResult>);
+type InferPromise<T> = T extends Promise<infer R> ? R : never;
 
-type AsyncResult = {
+type AsyncAction<T = any> =
+  | Promise<T>
+  | ((...args: T[]) => Promise<AsyncResult>);
+
+type AsyncResult<T = any> = {
   error?: any;
-  response?: any;
+  response?: InferPromise<AsyncAction<T>>;
 };
 
-export const onawait = (action: AsyncAction): Promise<AsyncResult> => {
+export function onawait<T extends Promise<any>>(
+  action: T
+): Promise<AsyncResult<T>> {
   return new Promise(async resolve => {
     try {
       const response = await action;
@@ -25,6 +31,6 @@ export const onawait = (action: AsyncAction): Promise<AsyncResult> => {
       return resolve(asyncError);
     }
   });
-};
+}
 
 export default onawait;


### PR DESCRIPTION
Hey 👋,

Small change utilizing typescript's [infer](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#type-inference-in-conditional-types) to automatically determine the types of the `response` object in the `AsyncResult` type.

An example to demonstrate:

```ts
import on from "./";

const getRandomNumber = (): Promise<number> => {
  return new Promise(resolve => setTimeout(() => resolve(Math.random()), 200));
};

const test = async () => {
  const { error, response } = await on(getRandomNumber());
};
```

TypeScript correctly infers `response` to be a `Promise<number> | undefined`

![image](https://user-images.githubusercontent.com/2430381/62816551-81454600-baf7-11e9-9df4-293fdf24d78c.png)

